### PR TITLE
🐛 Fix 403 errors when the url points to a directory without an index.html

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,11 +1,11 @@
 server {
   listen 80;
-  
+
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;
-    try_files $uri $uri/ /index.html =404;
+    try_files $uri /index.html =404;
   }
-  
+
   include /etc/nginx/extra-conf.d/*.conf;
 }


### PR DESCRIPTION
Currently if your static dir looks like
```
/index.html
/assets/asset.jpg
```
and you request `/assets`, nginx tries to serve the directory and 403s. I can't think of a use case where a frontend nginx would serve a directory - can we just remove this?

See https://stackoverflow.com/a/38046124