### PR TITLE
Tag latest image other than build it again

### DIFF
--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -5,10 +5,12 @@ set -x
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-docker build -t tiangolo/node-frontend:10 .
+TAG=${TAG:-10}
 
-docker build -t tiangolo/node-frontend:latest .
+docker build -t tiangolo/node-frontend:${TAG} .
 
-docker push tiangolo/node-frontend:10
+docker tag tiangolo/node-frontend:${TAG} tiangolo/node-frontend:latest
+
+docker push tiangolo/node-frontend:${TAG}
 
 docker push tiangolo/node-frontend:latest


### PR DESCRIPTION
Since the target image is exactly the latest version, there is no need to build it again.